### PR TITLE
feat(editor): add macOS Command+Enter shortcut for adding invoice items

### DIFF
--- a/frontend/i18n/locales/de.json
+++ b/frontend/i18n/locales/de.json
@@ -22,7 +22,7 @@
   "Issue Date": "Rechnungsdatum",
   "Due Date": "Fälligkeitsdatum",
   "Items": "Positionen",
-  "Ctrl+Enter to add": "Strg+Enter zum Hinzufügen",
+  "Ctrl+Enter to add": "Strg/Cmd+Enter zum Hinzufügen",
   "Add item": "Position hinzufügen",
   "Add at least one item with a description.": "Fügen Sie mindestens eine Position mit Beschreibung hinzu.",
   "Description": "Beschreibung",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -22,7 +22,7 @@
   "Issue Date": "Issue Date",
   "Due Date": "Due Date",
   "Items": "Items",
-  "Ctrl+Enter to add": "Ctrl+Enter to add",
+  "Ctrl+Enter to add": "Ctrl/Cmd+Enter to add",
   "Add item": "Add item",
   "Add at least one item with a description.": "Add at least one item with a description.",
   "Description": "Description",

--- a/frontend/i18n/locales/nl.json
+++ b/frontend/i18n/locales/nl.json
@@ -19,7 +19,7 @@
   "Issue Date": "Factuurdatum",
   "Due Date": "Vervaldatum",
   "Items": "Items",
-  "Ctrl+Enter to add": "Ctrl+Enter om toe te voegen",
+  "Ctrl+Enter to add": "Ctrl/Cmd+Enter om toe te voegen",
   "Add item": "Item toevoegen",
   "Add at least one item with a description.": "Voeg minstens één item met een omschrijving toe.",
   "Description": "Omschrijving",

--- a/frontend/i18n/locales/pt-br.json
+++ b/frontend/i18n/locales/pt-br.json
@@ -22,7 +22,7 @@
   "Issue Date": "Data de Emissão",
   "Due Date": "Data de Vencimento",
   "Items": "Itens",
-  "Ctrl+Enter to add": "Ctrl+Enter para adicionar",
+  "Ctrl+Enter to add": "Ctrl/Cmd+Enter para adicionar",
   "Add item": "Adicionar item",
   "Add at least one item with a description.": "Adicione pelo menos um item com descrição.",
   "Description": "Descrição",

--- a/frontend/islands/InvoiceEditorIsland.tsx
+++ b/frontend/islands/InvoiceEditorIsland.tsx
@@ -435,10 +435,12 @@ export default function InvoiceEditorIsland(props: InvoiceEditorProps) {
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
-      if (event.ctrlKey && (event.key === "s" || event.key === "S")) {
+      // Support both Ctrl (Windows/Linux) and Cmd (macOS)
+      const modifierPressed = event.ctrlKey || event.metaKey;
+      if (modifierPressed && (event.key === "s" || event.key === "S")) {
         event.preventDefault();
         formRef.current?.requestSubmit();
-      } else if (event.ctrlKey && event.key === "Enter") {
+      } else if (modifierPressed && event.key === "Enter") {
         event.preventDefault();
         handleAddItem();
       }
@@ -756,7 +758,7 @@ export default function InvoiceEditorIsland(props: InvoiceEditorProps) {
           <label class="block text-sm">
             Items <span aria-hidden="true" class="text-error">*</span>
             <span class="ml-2 text-xs text-base-content/50 font-normal">
-              (Ctrl+Enter to add)
+              (Ctrl/Cmd+Enter to add)
             </span>
           </label>
           <button


### PR DESCRIPTION
Added support for the Command key (metaKey) on macOS as an alternative to Ctrl for keyboard shortcuts in the invoice editor.

WHAT CHANGED:
- Keyboard handler now checks for both ctrlKey and metaKey
- Users can now use Ctrl+Enter (Windows/Linux) or Cmd+Enter (macOS) to add items
- Users can now use Ctrl+S or Cmd+S to save
- Updated hint text to show "Ctrl/Cmd+Enter to add"
- Updated all locale files (EN, DE, NL, PT-BR) with new shortcut text

This improves the user experience for macOS users who are accustomed to using the Command key instead of Control for keyboard shortcuts.
