### PR TITLE
Add GH action to check translations

### DIFF
--- a/.github/scripts/translations.py
+++ b/.github/scripts/translations.py
@@ -1,0 +1,395 @@
+import json
+from pathlib import Path
+
+
+main_locale = "en"
+
+root = Path(__file__).resolve().parent.parent.parent
+en = Path(root / "frontend/i18n/locales/en.json")
+files = [
+    f
+    for f in Path(root / "frontend/i18n/locales").glob("*.json")
+    if "en.json" not in str(f)
+]
+
+
+def get_reference_keys():
+    with open(en) as f:
+        data = json.load(f)
+        return data.keys()
+
+
+en_keys = get_reference_keys()
+
+
+def find_missing_translations(file):
+    lang = file.stem
+    with open(file) as f:
+        data = json.load(f)
+        missing = list(set(en_keys) - set(data.keys()))
+        return {
+            "file": file.name,
+            "lang": lang,
+            "missing": {"keys": missing, "count": len(missing)},
+        }
+
+
+def find_additional_translations(file):
+    with open(file) as f:
+        data = json.load(f)
+        additional = list(set(data.keys()) - set(en_keys))
+        return {"additional": {"keys": additional, "count": len(additional)}}
+
+
+result = []
+
+for file in files:
+    data = find_missing_translations(file)
+    data.update(find_additional_translations(file))
+    result.append(data)
+
+country_names = {
+    "ad": "Andorra",
+    "ae": "United Arab Emirates",
+    "af": "Afghanistan",
+    "ag": "Antigua and Barbuda",
+    "ai": "Anguilla",
+    "al": "Albania",
+    "am": "Armenia",
+    "ao": "Angola",
+    "aq": "Antarctica",
+    "ar": "Argentina",
+    "as": "American Samoa",
+    "at": "Austria",
+    "au": "Australia",
+    "aw": "Aruba",
+    "ax": "Åland Islands",
+    "az": "Azerbaijan",
+    "ba": "Bosnia and Herzegovina",
+    "bb": "Barbados",
+    "bd": "Bangladesh",
+    "be": "Belgium",
+    "bf": "Burkina Faso",
+    "bg": "Bulgaria",
+    "bh": "Bahrain",
+    "bi": "Burundi",
+    "bj": "Benin",
+    "bl": "Saint Barthélemy",
+    "bm": "Bermuda",
+    "bn": "Brunei",
+    "bo": "Bolivia",
+    "bq": "Caribbean Netherlands",
+    "br": "Brazil",
+    "bs": "Bahamas",
+    "bt": "Bhutan",
+    "bv": "Bouvet Island",
+    "bw": "Botswana",
+    "by": "Belarus",
+    "bz": "Belize",
+    "ca": "Canada",
+    "cc": "Cocos (Keeling) Islands",
+    "cd": "DR Congo",
+    "cf": "Central African Republic",
+    "cg": "Republic of the Congo",
+    "ch": "Switzerland",
+    "ci": "Côte d'Ivoire (Ivory Coast)",
+    "ck": "Cook Islands",
+    "cl": "Chile",
+    "cm": "Cameroon",
+    "cn": "China",
+    "co": "Colombia",
+    "cr": "Costa Rica",
+    "cu": "Cuba",
+    "cv": "Cape Verde",
+    "cw": "Curaçao",
+    "cx": "Christmas Island",
+    "cy": "Cyprus",
+    "cz": "Czechia",
+    "de": "Germany",
+    "dj": "Djibouti",
+    "dk": "Denmark",
+    "dm": "Dominica",
+    "do": "Dominican Republic",
+    "dz": "Algeria",
+    "ec": "Ecuador",
+    "ee": "Estonia",
+    "eg": "Egypt",
+    "eh": "Western Sahara",
+    "er": "Eritrea",
+    "es": "Spain",
+    "et": "Ethiopia",
+    "eu": "European Union",
+    "fi": "Finland",
+    "fj": "Fiji",
+    "fk": "Falkland Islands",
+    "fm": "Micronesia",
+    "fo": "Faroe Islands",
+    "fr": "France",
+    "ga": "Gabon",
+    "gb": "United Kingdom",
+    "gb-eng": "England",
+    "gb-nir": "Northern Ireland",
+    "gb-sct": "Scotland",
+    "gb-wls": "Wales",
+    "gd": "Grenada",
+    "ge": "Georgia",
+    "gf": "French Guiana",
+    "gg": "Guernsey",
+    "gh": "Ghana",
+    "gi": "Gibraltar",
+    "gl": "Greenland",
+    "gm": "Gambia",
+    "gn": "Guinea",
+    "gp": "Guadeloupe",
+    "gq": "Equatorial Guinea",
+    "gr": "Greece",
+    "gs": "South Georgia",
+    "gt": "Guatemala",
+    "gu": "Guam",
+    "gw": "Guinea-Bissau",
+    "gy": "Guyana",
+    "hk": "Hong Kong",
+    "hm": "Heard Island and McDonald Islands",
+    "hn": "Honduras",
+    "hr": "Croatia",
+    "ht": "Haiti",
+    "hu": "Hungary",
+    "id": "Indonesia",
+    "ie": "Ireland",
+    "il": "Israel",
+    "im": "Isle of Man",
+    "in": "India",
+    "io": "British Indian Ocean Territory",
+    "iq": "Iraq",
+    "ir": "Iran",
+    "is": "Iceland",
+    "it": "Italy",
+    "je": "Jersey",
+    "jm": "Jamaica",
+    "jo": "Jordan",
+    "jp": "Japan",
+    "ke": "Kenya",
+    "kg": "Kyrgyzstan",
+    "kh": "Cambodia",
+    "ki": "Kiribati",
+    "km": "Comoros",
+    "kn": "Saint Kitts and Nevis",
+    "kp": "North Korea",
+    "kr": "South Korea",
+    "kw": "Kuwait",
+    "ky": "Cayman Islands",
+    "kz": "Kazakhstan",
+    "la": "Laos",
+    "lb": "Lebanon",
+    "lc": "Saint Lucia",
+    "li": "Liechtenstein",
+    "lk": "Sri Lanka",
+    "lr": "Liberia",
+    "ls": "Lesotho",
+    "lt": "Lithuania",
+    "lu": "Luxembourg",
+    "lv": "Latvia",
+    "ly": "Libya",
+    "ma": "Morocco",
+    "mc": "Monaco",
+    "md": "Moldova",
+    "me": "Montenegro",
+    "mf": "Saint Martin",
+    "mg": "Madagascar",
+    "mh": "Marshall Islands",
+    "mk": "North Macedonia",
+    "ml": "Mali",
+    "mm": "Myanmar",
+    "mn": "Mongolia",
+    "mo": "Macau",
+    "mp": "Northern Mariana Islands",
+    "mq": "Martinique",
+    "mr": "Mauritania",
+    "ms": "Montserrat",
+    "mt": "Malta",
+    "mu": "Mauritius",
+    "mv": "Maldives",
+    "mw": "Malawi",
+    "mx": "Mexico",
+    "my": "Malaysia",
+    "mz": "Mozambique",
+    "na": "Namibia",
+    "nc": "New Caledonia",
+    "ne": "Niger",
+    "nf": "Norfolk Island",
+    "ng": "Nigeria",
+    "ni": "Nicaragua",
+    "nl": "Netherlands",
+    "no": "Norway",
+    "np": "Nepal",
+    "nr": "Nauru",
+    "nu": "Niue",
+    "nz": "New Zealand",
+    "om": "Oman",
+    "pa": "Panama",
+    "pe": "Peru",
+    "pf": "French Polynesia",
+    "pg": "Papua New Guinea",
+    "ph": "Philippines",
+    "pk": "Pakistan",
+    "pl": "Poland",
+    "pm": "Saint Pierre and Miquelon",
+    "pn": "Pitcairn Islands",
+    "pr": "Puerto Rico",
+    "ps": "Palestine",
+    "pt": "Portugal",
+    "pw": "Palau",
+    "py": "Paraguay",
+    "qa": "Qatar",
+    "re": "Réunion",
+    "ro": "Romania",
+    "rs": "Serbia",
+    "ru": "Russia",
+    "rw": "Rwanda",
+    "sa": "Saudi Arabia",
+    "sb": "Solomon Islands",
+    "sc": "Seychelles",
+    "sd": "Sudan",
+    "se": "Sweden",
+    "sg": "Singapore",
+    "sh": "Saint Helena, Ascension and Tristan da Cunha",
+    "si": "Slovenia",
+    "sj": "Svalbard and Jan Mayen",
+    "sk": "Slovakia",
+    "sl": "Sierra Leone",
+    "sm": "San Marino",
+    "sn": "Senegal",
+    "so": "Somalia",
+    "sr": "Suriname",
+    "ss": "South Sudan",
+    "st": "São Tomé and Príncipe",
+    "sv": "El Salvador",
+    "sx": "Sint Maarten",
+    "sy": "Syria",
+    "sz": "Eswatini (Swaziland)",
+    "tc": "Turks and Caicos Islands",
+    "td": "Chad",
+    "tf": "French Southern and Antarctic Lands",
+    "tg": "Togo",
+    "th": "Thailand",
+    "tj": "Tajikistan",
+    "tk": "Tokelau",
+    "tl": "Timor-Leste",
+    "tm": "Turkmenistan",
+    "tn": "Tunisia",
+    "to": "Tonga",
+    "tr": "Turkey",
+    "tt": "Trinidad and Tobago",
+    "tv": "Tuvalu",
+    "tw": "Taiwan",
+    "tz": "Tanzania",
+    "ua": "Ukraine",
+    "ug": "Uganda",
+    "um": "United States Minor Outlying Islands",
+    "un": "United Nations",
+    "us": "United States",
+    "us-ak": "Alaska",
+    "us-al": "Alabama",
+    "us-ar": "Arkansas",
+    "us-az": "Arizona",
+    "us-ca": "California",
+    "us-co": "Colorado",
+    "us-ct": "Connecticut",
+    "us-de": "Delaware",
+    "us-fl": "Florida",
+    "us-ga": "Georgia",
+    "us-hi": "Hawaii",
+    "us-ia": "Iowa",
+    "us-id": "Idaho",
+    "us-il": "Illinois",
+    "us-in": "Indiana",
+    "us-ks": "Kansas",
+    "us-ky": "Kentucky",
+    "us-la": "Louisiana",
+    "us-ma": "Massachusetts",
+    "us-md": "Maryland",
+    "us-me": "Maine",
+    "us-mi": "Michigan",
+    "us-mn": "Minnesota",
+    "us-mo": "Missouri",
+    "us-ms": "Mississippi",
+    "us-mt": "Montana",
+    "us-nc": "North Carolina",
+    "us-nd": "North Dakota",
+    "us-ne": "Nebraska",
+    "us-nh": "New Hampshire",
+    "us-nj": "New Jersey",
+    "us-nm": "New Mexico",
+    "us-nv": "Nevada",
+    "us-ny": "New York",
+    "us-oh": "Ohio",
+    "us-ok": "Oklahoma",
+    "us-or": "Oregon",
+    "us-pa": "Pennsylvania",
+    "us-ri": "Rhode Island",
+    "us-sc": "South Carolina",
+    "us-sd": "South Dakota",
+    "us-tn": "Tennessee",
+    "us-tx": "Texas",
+    "us-ut": "Utah",
+    "us-va": "Virginia",
+    "us-vt": "Vermont",
+    "us-wa": "Washington",
+    "us-wi": "Wisconsin",
+    "us-wv": "West Virginia",
+    "us-wy": "Wyoming",
+    "uy": "Uruguay",
+    "uz": "Uzbekistan",
+    "va": "Vatican City (Holy See)",
+    "vc": "Saint Vincent and the Grenadines",
+    "ve": "Venezuela",
+    "vg": "British Virgin Islands",
+    "vi": "United States Virgin Islands",
+    "vn": "Vietnam",
+    "vu": "Vanuatu",
+    "wf": "Wallis and Futuna",
+    "ws": "Samoa",
+    "xk": "Kosovo",
+    "ye": "Yemen",
+    "yt": "Mayotte",
+    "za": "South Africa",
+    "zm": "Zambia",
+    "zw": "Zimbabwe",
+}
+
+with open(root / "TRANSLATIONS.md", "w") as f:
+    f.write("# Translations that need your help\n\n")
+    for lang in result:
+        if "-" in lang["lang"]:
+            country = lang["lang"].rsplit("-", 1)[1]
+        else:
+            country = lang["lang"]
+        f.write(
+            f"## ![](https://flagcdn.com/w40/{country}.png) {country_names.get(country, 'Unknown county code' + country)}\n\n"
+        )
+
+        f.write(f"Translations file: `frontend/i18n/locales/{lang['file']}`\n\n")
+
+        f.write(f"### Additional translations: {lang['additional']['count']}\n\n")
+        f.write("> [!NOTE]\n")
+        f.write(
+            "> These translation appear in this translation file, but they are not part of the reference language (en).\n\n"
+        )
+        if lang["additional"]["count"] > 0:
+            for a in lang["additional"]["keys"]:
+                f.write(f"- {a}\n")
+            f.write("\n")
+        else:
+            f.write(":partying_face: No additional translations for this language found.\n\n")
+
+        f.write(f"### Missing translations: {lang['missing']['count']}\n\n")
+        if lang["missing"]["count"] > 0:
+            f.write("> [!NOTE]\n")
+            f.write(
+                "> These translation appear in the reference language (en), but are missing in this language.\n\n"
+            )
+            for m in lang["missing"]["keys"]:
+                f.write(f"- {m}\n")
+            f.write("\n")
+        else:
+            f.write(":partying_face: No missing translations for this language found.\n\n")

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,32 @@
+name: Check translation files 
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - frontend/i18n/locales/*
+  pull_request:
+    branches: [main]
+    paths:
+      - frontend/i18n/locales/*
+
+jobs:
+  check_translations:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13' 
+      - name: run check 
+        run: python .github/scripts/translations.py
+      - uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: Update missing translations
+          file_pattern: "TRANSLATIONS.md"


### PR DESCRIPTION
This PR adds a GitHub action that runs whenever a chage to a translation file is made. 
It then checks if there are additional or missing translations in one of the JSON files based on the en.json as reference.
The results get written to a TRANSLATIONS.md file, which is automatically commited and pushed.