### PR TITLE
Sort translation files

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -26,9 +26,19 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.13' 
+      - name: Sort translation files by key
+        run: | 
+          cd frontend/i18n/locales 
+          for file in *.json; do
+            jq --sort-keys . "$file" > "$file.tmp" 
+            if ! diff -q "$file" "$file.tmp" > /dev/null; then
+              echo "Sorted $file"
+            fi
+            mv "$file.tmp" "$file"
+          done
       - name: run check 
         run: python .github/scripts/translations.py
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: Update missing translations
-          file_pattern: "TRANSLATIONS.md"
+          commit_message: Update missing translations, sort translations
+          file_pattern: "TRANSLATIONS.md frontend/i18n/locales/*.json"


### PR DESCRIPTION
I just had a look at the translations files and is quite hard to find a translation because the fiels are not sorted.
So I thought it would make sense to add that to the `translations` action.

All .json files in `frontend/i18n/locales/` are sorted using `jq` and commited and pushed.