### PR TITLE
Fix dashboard overview

### DIFF
--- a/frontend/src/routes/dashboard/+page.server.ts
+++ b/frontend/src/routes/dashboard/+page.server.ts
@@ -44,8 +44,8 @@ export const load: PageServerLoad = async ({ locals, cookies }) => {
     const currency = (invoices[0]?.currency as string) || "USD";
     const dateFormat = String(settings.dateFormat || "YYYY-MM-DD");
     const billed = invoices.reduce((sum, i) => sum + (i.total || 0), 0);
-    const paid = invoices.filter((i) => i.status === "paid").reduce((s, i) => s + (i.total || 0), 0);
-    const outstanding = invoices.filter((i) => i.status === "sent" || i.status === "complete" || i.status === "overdue").reduce((s, i) => s + (i.total || 0), 0);
+    const paid = invoices.filter((i) => i.status === "paid" || i.status === "complete").reduce((s, i) => s + (i.total || 0), 0);
+    const outstanding = invoices.filter((i) => i.status === "sent" || i.status === "overdue").reduce((s, i) => s + (i.total || 0), 0);
     const status = {
       draft: invoices.filter((i) => i.status === "draft").length,
       sent: invoices.filter((i) => i.status === "sent").length,

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -78,7 +78,7 @@
       <div class="card-body p-4">
         <div class="text-xs sm:text-sm opacity-70">{t("Open Invoices")}</div>
         <div class="text-2xl sm:text-3xl font-extrabold">
-          {(statusCounts.sent || 0) + (statusCounts.complete || 0) + (statusCounts.overdue || 0)}
+          {(statusCounts.sent || 0) + (statusCounts.overdue || 0)}
         </div>
       </div>
     </div>
@@ -115,7 +115,7 @@
 {/if}
 
 {#if data.status}
-  <div class="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">
+  <div class="grid grid-cols-2 sm:grid-cols-6 gap-3 mb-6">
     <div class="card bg-base-100 border border-base-300 rounded-box">
       <div class="card-body p-4">
         <div class="text-xs sm:text-sm opacity-70">{t("Draft")}</div>
@@ -146,6 +146,12 @@
         <div class={`text-lg sm:text-xl font-semibold ${statusCounts.overdue > 0 ? "text-error" : ""}`}>
           {statusCounts.overdue || 0}
         </div>
+      </div>
+    </div>
+    <div class="card bg-base-100 border border-base-300 rounded-box">
+      <div class="card-body p-4">
+        <div class="text-xs sm:text-sm opacity-70">{t("Voided")}</div>
+        <div class="text-lg sm:text-xl font-semibold">{statusCounts.voided || 0}</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR fixes #92 

- Paid incoices now contain those with status `paid` and `completed`
- Outstanding invoices now contain those with status `sent` and `overdue`
- The dashboard now also shows the number of voided invoices

<img width="1659" height="422" alt="grafik" src="https://github.com/user-attachments/assets/a39c5f3c-b597-431b-b367-3ccbc01d315b" />
