### PR TITLE
Add more data to the customer overview

### DIFF
--- a/frontend/src/routes/customers/+page.svelte
+++ b/frontend/src/routes/customers/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { UserPlus } from "lucide-svelte";
   import { getContext } from "svelte";
+  import { formatPostalCityLine } from "$lib/address";
+  
+  const getLoc = getContext("localization") as () => any;
 
   let { data } = $props();
   let t = getContext("i18n") as (key: string) => string;
@@ -56,6 +59,9 @@
     <thead class="bg-base-200 text-base-content">
       <tr class="font-medium">
         <th>{t("Name")}</th>
+        <th>{t("Contact Name")}</th>
+        <th>{t("Address")}</th>
+        <th>{t("City")} / {t("Postal Code")}</th>
         <th>{t("Email")}</th>
       </tr>
     </thead>
@@ -65,6 +71,9 @@
           <td>
             <a class="link" href={`/customers/${c.id}`}>{c.name || c.id}</a>
           </td>
+          <td class="opacity-70">{c.contactName || ""}</td>
+          <td class="opacity-70">{c.address || ""}</td>
+          <td class="opacity-70">{formatPostalCityLine(c.city, c.postalCode, c.countryCode, getLoc()?.postalCityFormat) || "-"}</td>
           <td class="opacity-70">{c.email || ""}</td>
         </tr>
       {/each}


### PR DESCRIPTION
I find it hard to identify a customer only by its name.
This PR adds more data to the customer overview.

Before:

<img width="1520" height="226" alt="grafik" src="https://github.com/user-attachments/assets/beff64a8-5991-481d-a2c4-775d8820c48e" />

After:

<img width="1521" height="228" alt="grafik" src="https://github.com/user-attachments/assets/42801c21-4717-4671-9eef-c15b9492c480" />
