### PR TITLE
fix: company settings mapped to incorrect fields in frontend

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -481,13 +481,13 @@
                 ><div class="label">
                   <span class="label-text">{t("Email")}</span>
                 </div>
-                <input type="email" class="input input-bordered w-full" bind:value={settings.email} disabled={!canUpdateSettings} />
+                <input type="email" class="input input-bordered w-full" bind:value={settings.companyEmail} disabled={!canUpdateSettings} />
               </label>
               <label class="form-control"
                 ><div class="label">
                   <span class="label-text">{t("Phone")}</span>
                 </div>
-                <input type="text" class="input input-bordered w-full" bind:value={settings.phone} disabled={!canUpdateSettings} />
+                <input type="text" class="input input-bordered w-full" bind:value={settings.companyPhone} disabled={!canUpdateSettings} />
               </label>
             </div>
             <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -495,13 +495,13 @@
                 ><div class="label">
                   <span class="label-text">{t("Tax ID")}</span>
                 </div>
-                <input type="text" class="input input-bordered w-full" bind:value={settings.taxId} disabled={!canUpdateSettings} />
+                <input type="text" class="input input-bordered w-full" bind:value={settings.companyTaxId} disabled={!canUpdateSettings} />
               </label>
               <label class="form-control"
                 ><div class="label">
                   <span class="label-text">{t("Country Code")}</span>
                 </div>
-                <input type="text" class="input input-bordered w-full" bind:value={settings.countryCode} disabled={!canUpdateSettings} placeholder="US" />
+                <input type="text" class="input input-bordered w-full" bind:value={settings.companyCountryCode} disabled={!canUpdateSettings} placeholder="US" />
               </label>
             </div>
           </div>

--- a/frontend/src/routes/settings/components/SetupCompany.svelte
+++ b/frontend/src/routes/settings/components/SetupCompany.svelte
@@ -44,24 +44,24 @@
   <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
     <label class="form-control">
       <div class="label"><span class="label-text">{t("Email")}</span></div>
-      <input type="email" class="input input-bordered w-full" bind:value={settings.email} disabled={!canUpdateSettings} />
+      <input type="email" class="input input-bordered w-full" bind:value={settings.companyEmail} disabled={!canUpdateSettings} />
     </label>
     <label class="form-control">
       <div class="label"><span class="label-text">{t("Phone")}</span></div>
-      <input type="text" class="input input-bordered w-full" bind:value={settings.phone} disabled={!canUpdateSettings} />
+      <input type="text" class="input input-bordered w-full" bind:value={settings.companyPhone} disabled={!canUpdateSettings} />
     </label>
   </div>
 
   <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
     <label class="form-control">
       <div class="label"><span class="label-text">{t("Tax ID")}</span></div>
-      <input type="text" class="input input-bordered w-full" bind:value={settings.taxId} disabled={!canUpdateSettings} />
+      <input type="text" class="input input-bordered w-full" bind:value={settings.companyTaxId} disabled={!canUpdateSettings} />
     </label>
     <label class="form-control">
       <div class="label">
         <span class="label-text">{t("Country Code")}</span>
       </div>
-      <input type="text" class="input input-bordered w-full" bind:value={settings.countryCode} disabled={!canUpdateSettings} placeholder="US" />
+      <input type="text" class="input input-bordered w-full" bind:value={settings.companyCountryCode} disabled={!canUpdateSettings} placeholder="US" />
     </label>
   </div>
 </div>


### PR DESCRIPTION
Hi! 

Been looking into this project for a while, really like the idea of it all.

Have encountered a few bugs while playing around with the 2.0.1 version.

Seems more people have encountered this one specifically: #120 

**The bug:**

Some company settings fields will always render the default values to invoices. This is due to the ui setting the fields email, phone, taxId, countryCode instead of companyEmail, companyPhone, companyTaxId, companyCountryCode that is referenced by templates.

There is some mention of potential aliases here: https://github.com/kittendevv/Invio/blob/84d6d5c520a902f7a7818e6198c1287c874a9c05/backend/src/controllers/settings.ts#L19-L31 

That is never handled in anyway though and as a result, both versions are stored in the settings table in db.
```
companyPhone: default
phone: user-saved
```
This pr simply makes the UI reference the fields the way the rest of the app expects it to.
