### PR TITLE
Fix crypto.randomUUID error when running over HTTP

### DIFF
--- a/frontend/src/lib/components/InvoiceEditor.svelte
+++ b/frontend/src/lib/components/InvoiceEditor.svelte
@@ -2,6 +2,7 @@
   import { getContext, onMount, untrack } from "svelte";
   import { Plus, GripVertical } from "lucide-svelte";
   import { goto } from "$app/navigation";
+  import { generateId } from "$lib/utils/id";
 
   let { data, invoice = null, formId = "invoice-editor-form" } = $props();
   let initInvoice = untrack(() => invoice);
@@ -32,13 +33,13 @@
     initInvoice?.items?.length
       ? initInvoice.items.map((i: any) => ({
           ...i,
-          id: crypto.randomUUID(),
+          id: generateId(),
           unit: i.unit || "",
           productId: i.productId || "",
         }))
       : [
           {
-            id: crypto.randomUUID(),
+            id: generateId(),
             productId: "",
             description: "",
             quantity: 1,
@@ -56,7 +57,7 @@
 
   function addItem() {
     items.push({
-      id: crypto.randomUUID(),
+      id: generateId(),
       productId: "",
       description: "",
       quantity: 1,

--- a/frontend/src/lib/utils/id.ts
+++ b/frontend/src/lib/utils/id.ts
@@ -1,0 +1,8 @@
+/**
+ * Generate a unique ID using timestamp and random string
+ * Works in all browser contexts (HTTP, HTTPS, localhost)
+ * Suitable for UI state management (keys, drag-and-drop, etc.)
+ */
+export function generateId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
+}


### PR DESCRIPTION
## Summary

Fixes #115 - `crypto.randomUUID()` is only available in secure browser contexts (HTTPS or localhost), causing the invoice editor to fail when accessing Invio over HTTP on a local network.

## Changes

- Added `frontend/src/lib/utils/id.ts` with a `generateId()` utility function that works in all browser contexts
- Updated `frontend/src/lib/components/InvoiceEditor.svelte` to use `generateId()` instead of `crypto.randomUUID()`

## Technical Details

The new `generateId()` function uses `Date.now().toString(36)` combined with `Math.random().toString(36)` to generate unique IDs that are suitable for:
- Svelte keyed each blocks (`{#each items as item (item.id)}`)
- Drag-and-drop reordering state management

These IDs are UI-only (not sent to the server) and don't require cryptographically secure randomness.

## Test Plan

- [x] Start Invio on a local network machine without HTTPS
- [x] Access via `http://<ip>:<port>/invoices/new`
- [x] Verify invoice editor loads without console errors
