### PR TITLE
Return 'en' as locale for all countries with english as their primary language

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -163,6 +163,7 @@ function deriveLocaleFromCountryCode(countryCode?: string): string | undefined {
   if (code === "DE" || code === "AT" || code === "CH") return "de";
   if (code === "NL" || code === "BE") return "nl";
   if (code === "PT" || code === "BR") return "pt-br";
+  if (["AU", "CA", "GB", "IE", "NZ", "US", "AG", "BS", "BB", "BZ", "DM", "GD", "GY", "JM", "KN", "LC", "VC", "TT"].includes(code)) return "en";
 
   return undefined;
 }


### PR DESCRIPTION
This extends the fixed list of countries and their language by those with english as their primary language.
Those are obvious ones like the US, AU and so on and not so obvious ones like TT (Trinidad and Tobago) and BZ (Belize)

This helps mitigating #116 to some extent but not completely