### PR TITLE
Add per-customer sequential invoice numbering ({CSEQ}, {CNUM})

### DIFF
--- a/backend/src/controllers/customers.ts
+++ b/backend/src/controllers/customers.ts
@@ -12,9 +12,10 @@ const mapRowToCustomer = (row: unknown[]): Customer => ({
   countryCode: (row[6] ?? undefined) as string | undefined,
   taxId: (row[7] ?? undefined) as string | undefined,
   createdAt: new Date(row[8] as string),
-  // Optional city/postal_code columns if present at the end
+  // Optional city/postal_code/customer_number columns if present at the end
   city: (row[9] ?? undefined) as string | undefined,
   postalCode: (row[10] ?? undefined) as string | undefined,
+  customerNumber: (row[11] ?? undefined) as number | undefined,
 });
 
 export const getCustomers = () => {
@@ -23,7 +24,7 @@ export const getCustomers = () => {
   let results: unknown[][] = [];
   try {
     results = db.query(
-      "SELECT id, name, contact_name, email, phone, address, country_code, tax_id, created_at, city, postal_code FROM customers ORDER BY created_at DESC",
+      "SELECT id, name, contact_name, email, phone, address, country_code, tax_id, created_at, city, postal_code, customer_number FROM customers ORDER BY created_at DESC",
     ) as unknown[][];
   } catch (_e) {
     // fallback older schema
@@ -45,7 +46,7 @@ export const getCustomerById = (id: string): Customer | null => {
   let results: unknown[][] = [];
   try {
     results = db.query(
-      "SELECT id, name, contact_name, email, phone, address, country_code, tax_id, created_at, city, postal_code FROM customers WHERE id = ?",
+      "SELECT id, name, contact_name, email, phone, address, country_code, tax_id, created_at, city, postal_code, customer_number FROM customers WHERE id = ?",
       [id],
     ) as unknown[][];
   } catch (_e) {
@@ -71,10 +72,18 @@ const toNullable = (v?: string): string | null => {
   return s.length ? s : null;
 };
 
+const nextCustomerNumber = (db: ReturnType<typeof getDatabase>): number => {
+  const rows = db.query(
+    "SELECT COALESCE(MAX(customer_number), 0) FROM customers",
+  ) as unknown[][];
+  return Number((rows[0] as unknown[])[0]) + 1;
+};
+
 export const createCustomer = (data: CreateCustomerRequest): Customer => {
   const db = getDatabase();
   const customerId = generateUUID();
   const now = new Date();
+  const customerNumber = nextCustomerNumber(db);
 
   // Normalize optional fields: store NULLs for empty strings
   const contactName = toNullable(data.contactName);
@@ -89,8 +98,8 @@ export const createCustomer = (data: CreateCustomerRequest): Customer => {
   try {
     db.query(
       `
-      INSERT INTO customers (id, name, contact_name, email, phone, address, country_code, tax_id, created_at, city, postal_code)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO customers (id, name, contact_name, email, phone, address, country_code, tax_id, created_at, city, postal_code, customer_number)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
       [
         customerId,
@@ -104,6 +113,7 @@ export const createCustomer = (data: CreateCustomerRequest): Customer => {
         now,
         city,
         postal,
+        customerNumber,
       ],
     );
   } catch (_e) {
@@ -151,6 +161,7 @@ export const createCustomer = (data: CreateCustomerRequest): Customer => {
     createdAt: now,
     city: city ?? undefined,
     postalCode: postal ?? undefined,
+    customerNumber,
   };
 };
 

--- a/backend/src/controllers/invoices.ts
+++ b/backend/src/controllers/invoices.ts
@@ -246,14 +246,14 @@ export const createInvoice = (
       throw new Error("Invoice number already exists");
     }
   } else {
-    // If advanced numbering pattern with {SEQ} is active, allocate real number now; else draft placeholder
+    // If advanced numbering pattern with {SEQ} or {CSEQ} is active, allocate real number now; else draft placeholder
     try {
       const rows = db.query(
         "SELECT value FROM settings WHERE key = 'invoiceNumberPattern' LIMIT 1",
       );
       if (rows.length > 0) {
         const pattern = String((rows[0] as unknown[])[0] || "").trim();
-        if (pattern && /\{SEQ\}/.test(pattern)) {
+        if (pattern && /\{(C?SEQ)\}/.test(pattern)) {
           invoiceNumber = getNextInvoiceNumber(data.customerId);
         } else {
           invoiceNumber = generateDraftInvoiceNumber();

--- a/backend/src/controllers/invoices.ts
+++ b/backend/src/controllers/invoices.ts
@@ -254,7 +254,7 @@ export const createInvoice = (
       if (rows.length > 0) {
         const pattern = String((rows[0] as unknown[])[0] || "").trim();
         if (pattern && /\{SEQ\}/.test(pattern)) {
-          invoiceNumber = getNextInvoiceNumber();
+          invoiceNumber = getNextInvoiceNumber(data.customerId);
         } else {
           invoiceNumber = generateDraftInvoiceNumber();
         }
@@ -928,7 +928,9 @@ export const updateInvoice = async (
       !nextInvoiceNumber &&
       existing.invoiceNumber.startsWith("DRAFT-")
     ) {
-      const finalNum = getNextInvoiceNumber();
+      const finalNum = getNextInvoiceNumber(
+        data.customerId ?? existing.customerId,
+      );
       db.query(
         "UPDATE invoices SET invoice_number = ?, updated_at = ? WHERE id = ?",
         [finalNum, new Date(), id],
@@ -1242,7 +1244,7 @@ export const publishInvoice = async (
     const now = new Date();
     let num = invoice.invoiceNumber;
     if (num.startsWith("DRAFT-")) {
-      num = getNextInvoiceNumber();
+      num = getNextInvoiceNumber(invoice.customerId);
     }
     db.execute("BEGIN");
     try {

--- a/backend/src/controllers/invoices.ts
+++ b/backend/src/controllers/invoices.ts
@@ -246,14 +246,14 @@ export const createInvoice = (
       throw new Error("Invoice number already exists");
     }
   } else {
-    // If advanced numbering pattern with {SEQ} or {CSEQ} is active, allocate real number now; else draft placeholder
+    // If advanced numbering pattern with {SEQ}, {CSEQ}, or {CNUM} is active, allocate real number now; else draft placeholder
     try {
       const rows = db.query(
         "SELECT value FROM settings WHERE key = 'invoiceNumberPattern' LIMIT 1",
       );
       if (rows.length > 0) {
         const pattern = String((rows[0] as unknown[])[0] || "").trim();
-        if (pattern && /\{(C?SEQ)\}/.test(pattern)) {
+        if (pattern && /\{(C?SEQ|CNUM)\}/.test(pattern)) {
           invoiceNumber = getNextInvoiceNumber(data.customerId);
         } else {
           invoiceNumber = generateDraftInvoiceNumber();

--- a/backend/src/database/init.ts
+++ b/backend/src/database/init.ts
@@ -799,18 +799,31 @@ export function getNextInvoiceNumber(customerId?: string): string {
   // Advanced pattern mode (when enabled and configured)
   if (cfg.pattern && cfg.enabled) {
     const expanded = expandPatternTokens(cfg.pattern);
-    if (!/\{SEQ\}/.test(cfg.pattern)) return expanded;
+    const hasSeq = /\{SEQ\}/.test(cfg.pattern);
+    const hasClientSeq = /\{CSEQ\}/.test(cfg.pattern);
+    if (!hasSeq && !hasClientSeq) return expanded;
 
-    const prefix = expanded.split("{SEQ}")[0];
-    const next = findMaxSequence(prefix, customerId) + 1;
-    return expanded.replace(/\{SEQ\}/g, String(next).padStart(3, "0"));
+    let result = expanded;
+    if (hasSeq) {
+      // {SEQ}: global counter, shared across all customers
+      const prefix = expanded.split("{SEQ}")[0];
+      const next = findMaxSequence(prefix) + 1;
+      result = result.replace(/\{SEQ\}/g, String(next).padStart(3, "0"));
+    }
+    if (hasClientSeq) {
+      // {CSEQ}: counter scoped to this customer's own invoices
+      const prefix = expanded.split("{CSEQ}")[0];
+      const next = findMaxSequence(prefix, customerId) + 1;
+      result = result.replace(/\{CSEQ\}/g, String(next).padStart(3, "0"));
+    }
+    return result;
   }
 
-  // Legacy mode: PREFIX-YYYY-NNN
+  // Legacy mode: PREFIX-YYYY-NNN (global, no per-client variant)
   const base = cfg.includeYear
     ? `${cfg.prefix}-${new Date().getFullYear()}-`
     : `${cfg.prefix}-`;
-  const next = findMaxSequence(base, customerId) + 1;
+  const next = findMaxSequence(base) + 1;
   return `${base}${String(next).padStart(cfg.pad, "0")}`;
 }
 

--- a/backend/src/database/init.ts
+++ b/backend/src/database/init.ts
@@ -756,12 +756,17 @@ function getNumberingSettings(): {
   return cfg;
 }
 
-/** Find the highest existing sequential suffix matching `likePrefix%`. */
-function findMaxSequence(likePrefix: string): number {
-  const rows = db.query(
-    "SELECT invoice_number FROM invoices WHERE invoice_number LIKE ?",
-    [likePrefix + "%"],
-  );
+/** Find the highest existing sequential suffix matching `likePrefix%`, optionally scoped to a single customer. */
+function findMaxSequence(likePrefix: string, customerId?: string): number {
+  const rows = customerId
+    ? db.query(
+      "SELECT invoice_number FROM invoices WHERE invoice_number LIKE ? AND customer_id = ?",
+      [likePrefix + "%", customerId],
+    )
+    : db.query(
+      "SELECT invoice_number FROM invoices WHERE invoice_number LIKE ?",
+      [likePrefix + "%"],
+    );
   const escaped = likePrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(`^${escaped}(\\d+).*?$`);
   let max = 0;
@@ -788,7 +793,7 @@ function expandPatternTokens(pattern: string): string {
     .replace(/\{RAND4\}/g, () => cryptoRandom(4));
 }
 
-export function getNextInvoiceNumber(): string {
+export function getNextInvoiceNumber(customerId?: string): string {
   const cfg = getNumberingSettings();
 
   // Advanced pattern mode (when enabled and configured)
@@ -797,7 +802,7 @@ export function getNextInvoiceNumber(): string {
     if (!/\{SEQ\}/.test(cfg.pattern)) return expanded;
 
     const prefix = expanded.split("{SEQ}")[0];
-    const next = findMaxSequence(prefix) + 1;
+    const next = findMaxSequence(prefix, customerId) + 1;
     return expanded.replace(/\{SEQ\}/g, String(next).padStart(3, "0"));
   }
 
@@ -805,7 +810,7 @@ export function getNextInvoiceNumber(): string {
   const base = cfg.includeYear
     ? `${cfg.prefix}-${new Date().getFullYear()}-`
     : `${cfg.prefix}-`;
-  const next = findMaxSequence(base) + 1;
+  const next = findMaxSequence(base, customerId) + 1;
   return `${base}${String(next).padStart(cfg.pad, "0")}`;
 }
 

--- a/backend/src/database/init.ts
+++ b/backend/src/database/init.ts
@@ -160,6 +160,32 @@ function ensureCustomerColumns(database: DB): void {
   addColumnIfMissing(database, "customers", "country_code", "TEXT");
   addColumnIfMissing(database, "customers", "city", "TEXT");
   addColumnIfMissing(database, "customers", "postal_code", "TEXT");
+  addColumnIfMissing(database, "customers", "customer_number", "INTEGER");
+}
+
+/** Assign a permanent sequential customer_number (by creation order) to any customer missing one. */
+function backfillCustomerNumbers(database: DB): void {
+  const rows = database.query(
+    "SELECT id FROM customers WHERE customer_number IS NULL ORDER BY created_at ASC, id ASC",
+  ) as unknown[][];
+  if (rows.length === 0) return;
+
+  const maxRow = database.query(
+    "SELECT COALESCE(MAX(customer_number), 0) FROM customers",
+  ) as unknown[][];
+  let next = Number((maxRow[0] as unknown[])[0]) + 1;
+
+  for (const row of rows) {
+    database.query("UPDATE customers SET customer_number = ? WHERE id = ?", [
+      next,
+      String(row[0]),
+    ]);
+    next++;
+  }
+
+  console.log(
+    `  Backfilled customer_number for ${rows.length} existing customer(s).`,
+  );
 }
 
 function ensureInvoiceColumns(database: DB): void {
@@ -455,6 +481,7 @@ function migrateInvoicesForVoided(database: DB): void {
 function ensureSchemaUpgrades(database: DB): void {
   try {
     ensureCustomerColumns(database);
+    backfillCustomerNumbers(database);
     ensureInvoiceColumns(database);
     ensureTaxTables(database);
     ensureProductTables(database);
@@ -777,6 +804,22 @@ function findMaxSequence(likePrefix: string, customerId?: string): number {
   return max;
 }
 
+/** Look up a customer's permanent sequential customer_number, if any. */
+function getCustomerNumber(customerId?: string): number | null {
+  if (!customerId) return null;
+  try {
+    const rows = db.query(
+      "SELECT customer_number FROM customers WHERE id = ?",
+      [customerId],
+    ) as unknown[][];
+    if (rows.length === 0) return null;
+    const v = rows[0][0];
+    return v == null ? null : Number(v);
+  } catch {
+    return null;
+  }
+}
+
 /** Expand date/random tokens in an invoice-number pattern. */
 function expandPatternTokens(pattern: string): string {
   const now = new Date();
@@ -801,18 +844,32 @@ export function getNextInvoiceNumber(customerId?: string): string {
     const expanded = expandPatternTokens(cfg.pattern);
     const hasSeq = /\{SEQ\}/.test(cfg.pattern);
     const hasClientSeq = /\{CSEQ\}/.test(cfg.pattern);
-    if (!hasSeq && !hasClientSeq) return expanded;
+    const hasCustomerNum = /\{CNUM\}/.test(cfg.pattern);
+    if (!hasSeq && !hasClientSeq && !hasCustomerNum) return expanded;
 
     let result = expanded;
+    // {CNUM} must resolve first: {SEQ}/{CSEQ} scan existing invoice_number
+    // values using everything before them as a LIKE prefix, so that prefix
+    // has to be fully literal (no leftover {CNUM} placeholder) or it will
+    // never match a real stored invoice number and the counter always
+    // reads as empty (stuck at 1).
+    if (hasCustomerNum) {
+      // {CNUM}: the customer's own permanent sequential number
+      const custNum = getCustomerNumber(customerId);
+      result = result.replace(
+        /\{CNUM\}/g,
+        custNum != null ? String(custNum).padStart(3, "0") : "",
+      );
+    }
     if (hasSeq) {
       // {SEQ}: global counter, shared across all customers
-      const prefix = expanded.split("{SEQ}")[0];
+      const prefix = result.split("{SEQ}")[0];
       const next = findMaxSequence(prefix) + 1;
       result = result.replace(/\{SEQ\}/g, String(next).padStart(3, "0"));
     }
     if (hasClientSeq) {
       // {CSEQ}: counter scoped to this customer's own invoices
-      const prefix = expanded.split("{CSEQ}")[0];
+      const prefix = result.split("{CSEQ}")[0];
       const next = findMaxSequence(prefix, customerId) + 1;
       result = result.replace(/\{CSEQ\}/g, String(next).padStart(3, "0"));
     }

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -341,7 +341,8 @@ adminRoutes.get(
   requirePermission("invoices", "create"),
   (c) => {
     try {
-      const next = getNextInvoiceNumber();
+      const customerId = c.req.query("customerId") || undefined;
+      const next = getNextInvoiceNumber(customerId);
       return c.json({ next });
     } catch (e) {
       return c.json({ error: String(e) }, 500);

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -11,6 +11,7 @@ export interface Customer {
   taxId?: string;
   reference?: string; // BuyerReference or order ref
   createdAt: Date;
+  customerNumber?: number; // permanent sequential number, assigned at creation
 }
 
 export interface Product {

--- a/frontend/src/lib/components/InvoiceEditor.svelte
+++ b/frontend/src/lib/components/InvoiceEditor.svelte
@@ -13,6 +13,10 @@
 
   let saving = $state(false);
   let error = $state("");
+  // Tracks whether the user manually edited the invoice number, as opposed to
+  // it just holding the auto-computed preview (which must not be submitted as
+  // an explicit override — see the customerId-aware preview effect below).
+  let invoiceNumberTouched = $state(false);
 
   let form = $state({
     customerId: initInvoice?.customerId || "",
@@ -54,6 +58,22 @@
   let customers = $derived(data.customers || []);
   let products = $derived(data.products || []);
   let taxDefinitions = $derived(data.taxDefinitions || []);
+
+  // Re-preview the next invoice number whenever the customer changes, so
+  // customer-scoped patterns ({CSEQ}, {CNUM}) show something representative.
+  // Only for new invoices, and only while the user hasn't typed their own
+  // number — the actual final number is always assigned server-side.
+  $effect(() => {
+    if (initInvoice || invoiceNumberTouched) return;
+    const customerId = form.customerId;
+    const qs = customerId ? `?customerId=${encodeURIComponent(customerId)}` : "";
+    fetch(`/api/v1/invoices/next-number${qs}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (d?.next && !invoiceNumberTouched) form.invoiceNumber = d.next;
+      })
+      .catch(() => {});
+  });
 
   function addItem() {
     items.push({
@@ -172,6 +192,9 @@
     try {
       const payload = {
         ...form,
+        // Only send an explicit invoice number when creating if the user actually
+        // typed one; otherwise let the backend assign it using the real customerId.
+        invoiceNumber: !initInvoice && !invoiceNumberTouched ? undefined : form.invoiceNumber,
         pricesIncludeTax: form.pricesIncludeTax === "true",
         items: items.map((i) => ({
           productId: i.productId || undefined,
@@ -244,7 +267,7 @@
       <div class="label">
         <span class="label-text">{t("Invoice Number")}</span>
       </div>
-      <input type="text" class="input input-bordered w-full" placeholder={t("e.g. INV-2025-001")} bind:value={form.invoiceNumber} />
+      <input type="text" class="input input-bordered w-full" placeholder={t("e.g. INV-2025-001")} bind:value={form.invoiceNumber} oninput={() => (invoiceNumberTouched = true)} />
     </label>
 
     <label class="form-control">

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -608,6 +608,7 @@
                 <p>
                   <code>{"{SEQ}"}</code> (sequential, recommended),
                   <code>{"{CSEQ}"}</code> (sequential per customer),
+                  <code>{"{CNUM}"}</code> (customer's own number),
                   <code>{"{YYYY}"}</code>, <code>{"{YY}"}</code>,
                   <code>{"{MM}"}</code>, <code>{"{DD}"}</code>,
                   <code>{"{DATE}"}</code>, <code>{"{RAND4}"}</code>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -607,6 +607,7 @@
                 <p>{t("Available placeholders")}:</p>
                 <p>
                   <code>{"{SEQ}"}</code> (sequential, recommended),
+                  <code>{"{CSEQ}"}</code> (sequential per customer),
                   <code>{"{YYYY}"}</code>, <code>{"{YY}"}</code>,
                   <code>{"{MM}"}</code>, <code>{"{DD}"}</code>,
                   <code>{"{DATE}"}</code>, <code>{"{RAND4}"}</code>


### PR DESCRIPTION
## Summary

Invio's invoice numbering pattern only supports a single global counter (`{SEQ}`) — there's no way to give each customer their own independent invoice sequence, something Invoice Ninja and others support natively.

This PR adds two new, opt-in pattern tokens without changing any existing behavior:

- **`{CSEQ}`** — a sequential counter scoped to the invoice's customer (e.g. customer A's invoices go `001`, `002`, `003`... independently of customer B's).
- **`{CNUM}`** — the customer's own permanent number, auto-assigned in creation order when the customer is created (backfilled for existing customers). Useful for patterns like `INV-{CNUM}-{CSEQ}` → `INV-007-001`.

`{SEQ}` and the legacy `PREFIX-YYYY-NNN` mode are both untouched — existing users see no behavior change.

## Implementation

- `getNextInvoiceNumber()` now accepts an optional `customerId`, used only by `{CSEQ}`/`{CNUM}`. `findMaxSequence()` optionally scopes its `LIKE`-prefix query by `customer_id`.
- `{CNUM}` resolves before `{SEQ}`/`{CSEQ}` compute their prefix — otherwise the prefix would contain the literal unexpanded `{CNUM}` placeholder and never match a real stored invoice number, permanently stuck at 1. (Caught this in testing; worth calling out since it's non-obvious.)
- New nullable `customers.customer_number` column, backfilled by creation order (`created_at ASC`) for existing customers, assigned as `MAX(customer_number) + 1` on new customer creation. No changes to the `invoices` table — `customer_id` already existed there.
- Settings UI placeholder list updated to document both new tokens.

## Bug fix included                                                                                                        
While testing `{CSEQ}` against the "new invoice" screen, found that the invoice number input is prefilled with a preview fe*before* any customer is selected, and that value xplicit override — so `createInvoice` neveractually calls the auto-generation path with the real customer. Fixed by:                                                  - `/invoices/next-number` now accepts an optional
- The frontend preview re-fetches (customer-aware) whenever the selected customer changes, but is only included in the creapayload if the user actually typed their own numbeays computes the authoritative number from the real `customerId` at submit time.                                                                                               
## Testing                                                                                                                 
Verified the counter logic in isolation against a scratch SQLite database (interleaved invoices across multiple customers, confirmed `{SEQ}` stays global while `{CSEQ}`/`{CNstomer, including the CNUM-before-CSEQ orderingfix). Also deployed and manually exercised end-to-end against a real running instance, available at https://github.com/acolombo11/invio/pkgs/container/invio

