### PR TITLE
Sort the invoice customer dropdown alphabetically

### DIFF
--- a/frontend/src/lib/components/InvoiceEditor.svelte
+++ b/frontend/src/lib/components/InvoiceEditor.svelte
@@ -55,7 +55,17 @@
         ],
   );
 
-  let customers = $derived(data.customers || []);
+  // The API returns customers in creation order; sorting by name keeps the
+  // dropdown scannable once the list grows (locale-aware, so accented names
+  // land next to their base letter instead of after Z).
+  let customers = $derived(
+    [...(data.customers || [])].sort((a: any, b: any) =>
+      String(a?.name || "").localeCompare(String(b?.name || ""), undefined, {
+        numeric: true,
+        sensitivity: "base",
+      }),
+    ),
+  );
   let products = $derived(data.products || []);
   let taxDefinitions = $derived(data.taxDefinitions || []);
 


### PR DESCRIPTION
Fixes #131

## Problem

`/api/v1/customers` returns rows `ORDER BY created_at DESC`, and `InvoiceEditor.svelte` renders that order straight into the customer `<select>`. On both `/invoices/new` and `/invoices/[id]/edit` the dropdown is therefore ordered newest-first, which gets harder to scan as the customer list grows.

## Change

One file. The `customers` derived value in `InvoiceEditor.svelte` now sorts a copy of the list by name, using the same `localeCompare` options the invoice table already uses in `routes/invoices/+page.svelte`:

```js
String(a?.name || "").localeCompare(String(b?.name || ""), undefined, {
  numeric: true,
  sensitivity: "base",
})
```

Sorting client-side rather than in the SQL keeps the change scoped to the dropdown the issue is about. Changing `ORDER BY` in `controllers/customers.ts` would also flip the `/customers` listing away from newest-first, and SQLite `COLLATE NOCASE` is ASCII-only, so accented names would sort after Z. Happy to move it into the query instead if you would rather have it apply everywhere.

## Testing

Ran the backend and the SvelteKit dev server locally with seven customers created in deliberately non-alphabetical order.

Before:

```
Charlie & Co, Ökotec Berlin, Ärzte Zentrum Nord, Beta Ltd, Müller AG, alpha services, Zeppelin GmbH
```

After:

```
alpha services, Ärzte Zentrum Nord, Beta Ltd, Charlie & Co, Müller AG, Ökotec Berlin, Zeppelin GmbH
```

Casing is ignored, so `alpha services` sorts first rather than last, and `Ä`/`Ö` sort next to `A`/`O`.

Also checked on `/invoices/[id]/edit` that the list is sorted while the invoice's existing customer stays preselected, and that picking a different customer from the sorted dropdown saves correctly.

`bun run check` reports 0 errors, `eslint` is clean, and `bun run build` succeeds. `prettier --check` flags the same 5 files it already flags on an unmodified `main`; the changed file passes.