### PR TITLE
Allow multiple trusted origins for form submissions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ JWT_SECRET=change-me-in-production
 # For production:    https://yourdomain.com
 ORIGIN=http://localhost:8000
 
+# Extra origins allowed to submit forms (comma-separated, full origin incl. scheme+port).
+# Supports glob, e.g. http://*.ts.net:8003, or "*" to allow all (trusted networks only).
+# Optional; when unset, only ORIGIN is allowed.
+# TRUSTED_ORIGINS=
+
 # ─── Database ─────────────────────────────────────────────
 # Docker (default):     /app/data/invio.db
 # Local development:    ./invio.db

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -16,6 +16,7 @@
         "@sveltejs/kit": "^2.50.2",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
         "@tailwindcss/vite": "^4.1.18",
+        "@types/bun": "^1.4.0",
         "@types/node": "^25.5.1",
         "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^10.2.0",
@@ -223,6 +224,8 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
@@ -268,6 +271,8 @@
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "bun test"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^7.0.0",
@@ -21,6 +22,7 @@
     "@sveltejs/kit": "^2.50.2",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@tailwindcss/vite": "^4.1.18",
+    "@types/bun": "^1.4.0",
     "@types/node": "^25.5.1",
     "@typescript-eslint/parser": "^8.59.0",
     "eslint": "^10.2.0",

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,9 +1,42 @@
-import type { Handle } from "@sveltejs/kit";
+import { dev } from "$app/environment";
+import { error, type Handle } from "@sveltejs/kit";
+import { env } from "$env/dynamic/private";
 import { resolveLocalization, DEFAULT_LOCALIZATION } from "$lib/i18n/mod";
 import { getAuthHeaderFromCookie } from "$lib/auth";
 import { backendGet } from "$lib/backend";
+import {
+  isMutatingFormRequest,
+  originAllowed,
+  originMatchesRequestHost,
+  parseAllowedOrigins,
+} from "$lib/csrf";
+
+function assertTrustedFormOrigin(event: Parameters<Handle>[0]["event"]): void {
+  if (!isMutatingFormRequest(event.request)) {
+    return;
+  }
+
+  const origin = event.request.headers.get("origin") ?? "";
+  const allowedOrigins = parseAllowedOrigins(env.ORIGIN, env.TRUSTED_ORIGINS);
+
+  const allowed =
+    allowedOrigins.length > 0
+      ? originAllowed(origin, allowedOrigins)
+      : originMatchesRequestHost(origin, event.request.headers.get("host"));
+
+  if (!allowed) {
+    error(
+      403,
+      `Cross-site ${event.request.method} form submissions are forbidden`,
+    );
+  }
+}
 
 export const handle: Handle = async ({ event, resolve }) => {
+  if (!dev) {
+    assertTrustedFormOrigin(event);
+  }
+
   const cookieString = event.request.headers.get("cookie");
 
   // Auth

--- a/frontend/src/lib/csrf.test.ts
+++ b/frontend/src/lib/csrf.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+  originAllowed,
+  originMatchesRequestHost,
+  parseAllowedOrigins,
+  isMutatingFormRequest,
+} from "./csrf";
+
+describe("originAllowed", () => {
+  test("exact match", () => {
+    expect(
+      originAllowed("http://localhost:8000", ["http://localhost:8000"]),
+    ).toBe(true);
+  });
+
+  test("hostname mismatch is denied", () => {
+    expect(
+      originAllowed("http://127.0.0.1:8000", ["http://localhost:8000"]),
+    ).toBe(false);
+  });
+
+  test("missing origin is denied", () => {
+    expect(originAllowed("", ["http://localhost:8000"])).toBe(false);
+    expect(originAllowed("", ["*"])).toBe(false);
+  });
+
+  test("wildcard allows any origin", () => {
+    expect(originAllowed("http://evil.example:8000", ["*"])).toBe(true);
+  });
+
+  test("glob matches Tailscale MagicDNS", () => {
+    expect(
+      originAllowed("http://umbrel-home.tailf2e95.ts.net:8003", [
+        "http://*.ts.net:8003",
+      ]),
+    ).toBe(true);
+  });
+
+  test("glob rejects other hosts and ports", () => {
+    expect(
+      originAllowed("http://evil.example:8003", ["http://*.ts.net:8003"]),
+    ).toBe(false);
+    expect(
+      originAllowed("http://umbrel-home.tailf2e95.ts.net:8000", [
+        "http://*.ts.net:8003",
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("parseAllowedOrigins", () => {
+  test("ORIGIN only", () => {
+    expect(parseAllowedOrigins("http://umbrel.local:8003", undefined)).toEqual([
+      "http://umbrel.local:8003",
+    ]);
+  });
+
+  test("ORIGIN plus TRUSTED_ORIGINS", () => {
+    expect(
+      parseAllowedOrigins(
+        "http://app.local:8000",
+        "http://tailscale.local:8000, http://*.ts.net:8003",
+      ),
+    ).toEqual([
+      "http://app.local:8000",
+      "http://tailscale.local:8000",
+      "http://*.ts.net:8003",
+    ]);
+  });
+
+  test("both env vars empty yields empty list", () => {
+    expect(parseAllowedOrigins(undefined, undefined)).toEqual([]);
+    expect(parseAllowedOrigins("", "")).toEqual([]);
+  });
+});
+
+describe("originMatchesRequestHost", () => {
+  test("matches Host including port, ignoring http vs https", () => {
+    expect(
+      originMatchesRequestHost("http://app.local:18000", "app.local:18000"),
+    ).toBe(true);
+    expect(
+      originMatchesRequestHost("https://app.local:18000", "app.local:18000"),
+    ).toBe(true);
+  });
+
+  test("rejects a different hostname", () => {
+    expect(
+      originMatchesRequestHost(
+        "http://tailscale.local:18000",
+        "app.local:18000",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isMutatingFormRequest", () => {
+  test("login form POST is checked", () => {
+    const request = new Request("http://localhost/login?/login", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+    expect(isMutatingFormRequest(request)).toBe(true);
+  });
+
+  test("GET is not checked", () => {
+    const request = new Request("http://localhost/login");
+    expect(isMutatingFormRequest(request)).toBe(false);
+  });
+});

--- a/frontend/src/lib/csrf.ts
+++ b/frontend/src/lib/csrf.ts
@@ -1,0 +1,67 @@
+const FORM_CONTENT_TYPES = new Set([
+  "application/x-www-form-urlencoded",
+  "multipart/form-data",
+  "text/plain",
+]);
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export function isFormContentType(request: Request): boolean {
+  const type =
+    request.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      .trim()
+      .toLowerCase() ?? "";
+  return FORM_CONTENT_TYPES.has(type);
+}
+
+export function isMutatingFormRequest(request: Request): boolean {
+  return MUTATING_METHODS.has(request.method) && isFormContentType(request);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function originAllowed(origin: string, patterns: string[]): boolean {
+  if (!origin) return false;
+  for (const pattern of patterns) {
+    if (pattern === "*") return true;
+    if (pattern === origin) return true;
+    if (pattern.includes("*")) {
+      const regex = new RegExp(
+        "^" + pattern.split("*").map(escapeRegex).join(".+") + "$",
+      );
+      if (regex.test(origin)) return true;
+    }
+  }
+  return false;
+}
+
+export function parseAllowedOrigins(
+  originEnv: string | undefined,
+  trustedOriginsEnv: string | undefined,
+): string[] {
+  return [
+    ...(originEnv?.trim() ? [originEnv.trim()] : []),
+    ...(trustedOriginsEnv ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  ];
+}
+
+/** True when Origin's host[:port] matches the incoming Host header (scheme ignored). */
+export function originMatchesRequestHost(
+  origin: string,
+  hostHeader: string | null | undefined,
+): boolean {
+  if (!origin || !hostHeader) return false;
+  try {
+    const originUrl = new URL(origin);
+    return originUrl.host === hostHeader || originUrl.hostname === hostHeader;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -6,6 +6,9 @@ const config = {
     adapter: adapter({
       out: "build",
     }),
+    csrf: {
+      trustedOrigins: ["*"],
+    },
   },
   vitePlugin: {
     dynamicCompileOptions: ({ filename }) =>


### PR DESCRIPTION
## Summary

Adds an optional `TRUSTED_ORIGINS` env var so self-hosted deployments can accept form POSTs from more than one hostname (e.g. Umbrel `.local` plus Tailscale MagicDNS or LAN IP), while keeping CSRF protection enabled.

Existing installs with only `ORIGIN` set are unaffected — `TRUSTED_ORIGINS` is purely additive.

Fixes #133

## Problem

When Invio is accessed over a hostname different from the configured `ORIGIN`, login and other form actions fail with:

```json
{\"message\":\"Cross-site POST form submissions are forbidden\"}
```

Common example (Umbrel):

- Local: `http://umbrel.local:8003` — works
- Tailscale: `http://umbrel-home.<tailnet>.ts.net:8003` — rejected

SvelteKit's built-in CSRF only compares `Origin` against one server-side origin, and `csrf.trustedOrigins` in `svelte.config.js` is build-time — not configurable per install.

## Solution

Move the CSRF origin gate into `hooks.server.ts` so the allowlist can be set at runtime:

- `ORIGIN` — canonical origin (unchanged; still respected)
- `TRUSTED_ORIGINS` — optional comma-separated extra origins
  - exact origins: `http://tailscale.local:8000`
  - glob: `http://*.ts.net:8003`
  - `*` to allow all (trusted networks only)
- Skipped in dev (matches SvelteKit's built-in behavior)
- When neither env var is set, allow same-host form posts only (Origin host matches request Host, scheme ignored). This fixes HTTP deployments where adapter-node would otherwise default to `https://` origin.

## Backward compatibility

| Existing setup | Change needed? |
|---|---|
| `ORIGIN=http://localhost:8000` only (Docker) | No |
| `ORIGIN=http://\${DEVICE_DOMAIN_NAME}:8003` only (Umbrel) | No |
| `vite dev` without env vars | No (skipped in dev) |
| Tailscale / LAN IP access | Opt in via `TRUSTED_ORIGINS` |

## Testing

- Bun unit tests in `frontend/src/lib/csrf.test.ts` covering exact, glob, wildcard, missing origin, and Host-header fallback (`bun run test`)
- Type check: `bun run check` — 0 errors (4 pre-existing warnings unrelated to this PR)
- Verified locally with a production-mode sandbox (adapter-node + Deno backend) POSTing `/login?/login` from multiple hostnames via `curl --resolve`, all scenarios pass (canonical, extra trusted origin, glob, wildcard, empty-env same-host, blocked cross-host)

## For Umbrel packaging (separate PR)

After this ships, the `umbrel-apps` `invio/docker-compose.yml` frontend service can add:

```yaml
TRUSTED_ORIGINS: \"http://\${DEVICE_DOMAIN_NAME}:8003,http://\${DEVICE_HOSTNAME}:8003,http://*.ts.net:8003\"
```

## Files

- `frontend/svelte.config.js` — disable built-in origin gate (delegated to hook)
- `frontend/src/hooks.server.ts` — production-only runtime CSRF check
- `frontend/src/lib/csrf.ts` — matcher (exact/glob/wildcard + host-header fallback)
- `frontend/src/lib/csrf.test.ts` — 13 unit tests
- `frontend/package.json` — add `test` script and `@types/bun` devDependency
- `.env.example` — document `TRUSTED_ORIGINS`

Made with [Cursor](https://cursor.com)